### PR TITLE
fix inaccurate survived_rej column in events data frame

### DIFF
--- a/MnePreproc.py
+++ b/MnePreproc.py
@@ -392,8 +392,8 @@ class MnePreproc:
                 blink = load.unpickle(rej_files[0])
                 idx = blink['accept'].x
             elif op.splitext(rej_files[0])[1] == '.txt': # if it's a regular text file, load into pandas DataFrame
-                blink = pandas.DataFrame.from_csv(rej_files[0], sep='\t', index_col=False)
-                idx = blink['accept']
+                blink = pandas.DataFrame.from_csv(rej_files[0], sep='\t', index_col=None)
+                idx = blink['accept'].values
 
             self.epochs_clean = self.epochs[idx]
             self.ds_events['survived_rej'] = idx

--- a/MnePreproc.py
+++ b/MnePreproc.py
@@ -458,9 +458,7 @@ class MnePreproc:
 
         if not op.exists(fname):
 
-            cov = mne.cov.compute_covariance(self.epochs_clean, tmax = 0, method=method)
-            cov_reg = mne.cov.regularize(cov, self.grand_average_evoked.info, mag=0.05,
-                                         grad = 0.05, proj = True, exclude = 'bads')
+            cov_reg = mne.cov.compute_covariance(self.epochs_clean, tmax = 0, method=method)
 
             mne.write_cov(fname, cov_reg)
 


### PR DESCRIPTION
Sorry for the back-to-back pull requests. The `survived_rej` column in the `MnePreproc.ds_events` data frame was added wrong after blink rejection.
